### PR TITLE
Fix connection to the Redis instance.

### DIFF
--- a/lib/redisearch.rb
+++ b/lib/redisearch.rb
@@ -229,10 +229,16 @@ class RediSearch
   # @return [mixed] The output returned by redis
   def call(command)
     raise ArgumentError.new("unknown/unsupported command '#{command.first}'") unless valid_command?(command.first)
-    @redis.with_reconnect { @redis.call(command.flatten) }
+    @redis.method(connection).call { |conn| conn.call(command) }
   end
 
   private
+
+  def connection
+    return :with_reconnect if @redis.respond_to?(:with_reconnect)
+
+    :with
+  end
 
   def with_reconnect
     @redis.with_reconnect { yield }

--- a/lib/redisearch.rb
+++ b/lib/redisearch.rb
@@ -229,7 +229,7 @@ class RediSearch
   # @return [mixed] The output returned by redis
   def call(command)
     raise ArgumentError.new("unknown/unsupported command '#{command.first}'") unless valid_command?(command.first)
-    @redis.method(connection).call { |conn| conn.call(command) }
+    @redis.method(connection) { @redis.call(command.flatten) }
   end
 
   private


### PR DESCRIPTION
Description:
This pull request addresses the issue of the removed #with_reconnect method in the Redis library by implementing a workaround.

Changes Made:

Added a workaround for the removed #with_reconnect method in the Redis library. Implemented a new method to handle reconnection to the Redis instance. Updated the affected code to use the new reconnection method. Reason for Changes:
The Redis library removed the #with_reconnect method, which was causing issues with the connection to the Redis instance. To fix this, I have added a workaround that handles the connection process.